### PR TITLE
ci(hardening): pin actions by SHA, harden the runner, scope permissions

### DIFF
--- a/.github/workflows/weekly-software-check.yml
+++ b/.github/workflows/weekly-software-check.yml
@@ -9,20 +9,24 @@ concurrency:
   group: weekly-software-check
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   # ── Homebrew ──────────────────────────────────────────────────────────────
   check-brew:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Cache Homebrew
         id: cache-homebrew
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /home/linuxbrew/.linuxbrew
           key: homebrew-${{ runner.os }}-v1
@@ -100,7 +104,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: brew-results
           retention-days: 1
@@ -111,12 +115,19 @@ jobs:
   # ── PR ────────────────────────────────────────────────────────────────────
   create-pr:
     needs: [check-brew]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write      # the branch the PR is opened from
+      pull-requests: write  # opening the PR itself
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Download brew results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: brew-results
           path: /tmp/brew-results
@@ -143,7 +154,7 @@ jobs:
           } > /tmp/pr_body.txt
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/weekly-software-check

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+    "labels": ["dependencies"],
+    "assignees": ["PixiBixi"],
+    "semanticCommits": "enabled",
+    "pinDigests": true,
+    "packageRules": [
+        {
+            "description": "Cooldown before automerge picks up a release: a hijacked package is usually spotted and yanked within days. digest is in here because a digest-only update means an upstream tag moved onto another commit. vulnerabilityAlerts overrides this, so CVE fixes still land at once",
+            "matchUpdateTypes": ["major", "minor", "patch", "digest"],
+            "minimumReleaseAge": "5 days"
+        },
+        {
+            "description": "Automerge all safe updates (minor/patch/digest) via PR once CI passes",
+            "matchUpdateTypes": ["minor", "patch", "digest"],
+            "automerge": true,
+            "automergeType": "pr"
+        },
+        {
+            "description": "Actions do not ship in any artifact -> group them into one chore PR. github-runners is a datasource rather than a manager, so the github-actions manager carries the runner labels too",
+            "matchManagers": ["github-actions"],
+            "groupName": "github-actions",
+            "semanticCommitType": "chore"
+        }
+    ]
+}


### PR DESCRIPTION
StepSecurity flagged six unpinned actions in `weekly-software-check.yml`.

## Pinning

A tag can be moved onto another commit, so a pinned tag is not a pinned dependency. All six actions now carry the full commit SHA with the tag kept as a comment, which is the form Renovate maintains:

`actions/checkout@v4` (x2), `actions/cache@v4`, `actions/upload-artifact@v4`, `actions/download-artifact@v4`, `peter-evans/create-pull-request@v7`.

## Permissions

The workflow declared `contents: write` and `pull-requests: write` at the **workflow** level, so both jobs inherited them. `check-brew` only reads: it now gets `contents: read`. Only `create-pr` keeps the write scopes, and each is commented with what needs it. Top level is `permissions: {}`.

This matters more here than elsewhere: `create-pr` runs `peter-evans/create-pull-request`, and a job that can both write contents and open PRs is the one worth keeping narrow.

## Also

- `step-security/harden-runner` in audit mode on both jobs.
- `ubuntu-latest` -> `ubuntu-24.04`, so a runner image bump is a visible change rather than a silent one.
- Adds `renovate.json` (there was none), so the new SHAs get maintained instead of frozen. Same config as the Go repos minus the Go-specific rules: 5-day cooldown, automerge on minor/patch/digest, actions grouped into one `chore` PR.