### PR TITLE
docs(security): add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported versions
+
+There are no releases here: the supported version is whatever is on `master`.
+
+## Reporting a vulnerability
+
+Report privately through GitHub's [security advisory form][advisory]. Please
+do not open a public issue for a vulnerability.
+
+[advisory]: https://github.com/PixiBixi/dotfiles/security/advisories/new
+
+Expect an acknowledgement within 7 days. If the report is confirmed, the fix
+lands on `master` and the advisory is published once it is available.
+
+This is a personal project maintained on a best-effort basis, with no service
+level commitment.
+
+## Scope
+
+In scope: the shell configuration, scripts and CI in this repository.
+
+Out of scope: vulnerabilities in upstream dependencies, which belong to their
+own maintainers, and issues that require an already-compromised environment.


### PR DESCRIPTION
The last public repo without a `SECURITY.md`. This one holds shell configuration and CI that people copy from, and there was no private channel to report a problem in it: the only route was a public issue.

Adapted to this repo rather than copied verbatim: there are no releases here, so the supported version is whatever is on `master`, and the scope names the shell configuration and CI rather than published artifacts.

`website` is the only repo left without one, deliberately: it is private, so there is no outside reporter to address.