### PR TITLE
chore(codeowners): declare a single owner for every path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# One owner for every path: GitHub requests a review from @PixiBixi on any pull
+# request he did not open himself. The matching branch protection toggle stays
+# off on purpose, see the pull request that added this file.
+* @PixiBixi


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @PixiBixi`.

## What it does

GitHub automatically requests a review from the owner on any PR the owner did not open, and shows the ownership on every file view. On a Renovate or Dependabot PR that means the review request lands without anyone thinking about it.

## What I deliberately did not turn on

The branch protection flag `require_code_owner_reviews` stays **off**, and this is the part worth reading before flipping it:

- Code owner review only has an effect with `required_approving_review_count >= 1`. Today it is 0.
- **GitHub forbids approving your own pull request.** As sole owner, every PR you open would need an approval nobody can give. You could still merge as admin (`enforce_admins` is false), but that turns every single merge into `gh pr merge --admin`.
- **It would stop Renovate automerging anything.** Renovate waits for the required approval, which only you can click, on all 12 repos. That is the whole point of the automerge setup gone.

The gain would be about one point on the Scorecard Branch-Protection check, which stays capped anyway for the reasons already documented.

If you want it despite that, it is one call per repo:

```sh
gh api -X PATCH repos/PixiBixi/REPO/branches/BRANCH/protection/required_pull_request_reviews \
  -F required_approving_review_count=1 -F require_code_owner_reviews=true
```